### PR TITLE
Change .gitignore and add mimetype to routes.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ app/static/npm/node_modules/**/*
 venv
 *.swp
 app/__pycache__
+__pycache__
 tmp

--- a/app/routes.py
+++ b/app/routes.py
@@ -2,8 +2,11 @@ from flask import Flask, url_for, redirect, render_template, session
 from dotenv import load_dotenv
 from os import getenv
 from authlib.integrations.flask_client import OAuth
+import mimetypes
 
 from app import app
+
+mimetypes.add_type('application/javascript', '.js')
 
 oauth = OAuth(app)
 github = oauth.register(


### PR DESCRIPTION
Add `__pycache__` to .gitignore.

When running mei-friend locally on a Windows machine, the mimetype js needs to be added to routes.py to work properly (see also install). The second commit contains this change. If this does not cause any problem on non-Windows machines, it would be kind to add...