### PR TITLE
Fix basic markup bugs after workshop

### DIFF
--- a/app/static/lib/editor.js
+++ b/app/static/lib/editor.js
@@ -958,6 +958,7 @@ export function addTranscriptionLikeElement(v, cm, attrName = 'none', mElName = 
 
   let uuids = [];
   let elementGroups = [];
+  let abort = false;
 
   // this loop updated the list of selected elements to be wrapped by markup
   // and will separate the list into groups of adjacent elements to be wrapped into a single markup element
@@ -1039,6 +1040,17 @@ export function addTranscriptionLikeElement(v, cm, attrName = 'none', mElName = 
       let id = group[i];
       let el = v.xmlDoc.querySelector("[*|id='" + id + "']");
       let currentParent = el.parentNode;
+
+      // warn and prevent if currentParrent has no xml:id because replacing in editor will fail
+      // TODO: add option to add xml:ids to the file before adding markup
+      // TODO: add setting to automatically add xml:ids to a file
+      if(currentParent && currentParent.getAttribute('xml:id') == null) {
+        const msg = "Action can only be performed if parent element has an xml:id. Please add xml:ids to the document before.";
+        console.log(msg);
+        v.showAlert(msg, 'warning');
+        abort = true;
+        return;
+      }
       
       // special treatment of the first element for id generation and to place sup within the tree (and a sanity check)
       if(i === 0) {
@@ -1068,6 +1080,7 @@ export function addTranscriptionLikeElement(v, cm, attrName = 'none', mElName = 
   // TODO (nice to have): Add @corresp to elements if more than one is created at once
 
   // buffer.groupChangesSinceCheckpoint(checkPoint); // TODO
+  if (abort === true) return;
   v.selectedElements = [];
   uuids.forEach((u) => v.selectedElements.push(u));
   addApplicationInfo(v, cm);

--- a/app/static/lib/speed.js
+++ b/app/static/lib/speed.js
@@ -1228,10 +1228,10 @@ export function countStaves(scoreDef) {
  */
 export function filterElements(ids, xmlDoc) {
   for (let i = 0; i < ids.length; i++) {
-    for (let j = i + 1; j < ids.length; j++) {
+    for (let j = 0; j < ids.length; j++) {
       const elj = xmlDoc.querySelector('[*|id="' + ids[j] + '"]');
       if (!elj) continue;
-      if (elj.closest('[*|id="' + ids[i] + '"]')) {
+      if (elj.parentElement && elj.parentElement.closest('[*|id="' + ids[i] + '"]')) {
         ids.splice(j--, 1);
       }
     }


### PR DESCRIPTION
1. Fix `speed.filterElements()` to filter accidentals as first element within a selection
2. Add warning and abort `addTranskriptionLikeMarkup()` if parent element has no xml:id

By the way: Could you please push other bugfixes to this branch as well? 🤓 