### PR TITLE
Fix GH integration for filenames with collapsable whitespace

### DIFF
--- a/app/static/css/navbar.css
+++ b/app/static/css/navbar.css
@@ -171,6 +171,15 @@
   display: block;
 }
 
+/* Show all the whitespace in the github dropdown file names
+   - Whitespace in filenames is significant, so users should see it if it's there
+   - Since the filenames are stored on the DOM, letting the browser collapse
+     whitespace breaks the ability of the github integration to open files with
+     collapsable whitespace sequences in their names */
+.branchContents {
+  white-space: break-spaces;
+}
+
 #logTable {
   font-size: 8pt;
   white-space: nowrap;

--- a/app/static/css/navbar.css
+++ b/app/static/css/navbar.css
@@ -177,7 +177,7 @@
      whitespace breaks the ability of the github integration to open files with
      collapsable whitespace sequences in their names */
 .branchContents {
-  white-space: break-spaces;
+  white-space: pre;
 }
 
 #logTable {


### PR DESCRIPTION
Since the GitHub integration retrieves filenames directly from the DOM, and HTML collapses sequences of repeated whitespace, it was unable to load files whose names contained such whitespace sequences. Switch to a whitespace-preserving setting for `white-space` so the whitespace will be preserved.

This has the side effect of also showing all whitespace in filenames to users, which is probably also a good thing.

Fixes #95 

Note: using `pre` means filenames will not be able to be wrapped if they get too long. I think this is probably the right move, since the next best option `break-spaces` only allows line-breaking at spaces and most filenames won't contain spaces anyways, but it's a good thing to keep in mind.