### PR TITLE
Auto-generate xml:ids when parsing markup

### DIFF
--- a/app/static/lib/markup.js
+++ b/app/static/lib/markup.js
@@ -58,8 +58,17 @@ export function readMarkup() {
     if (!idsToIgnore.includes(elId)) {
       let elName = markupEl.localName;
       if (elId == null) {
+        // (AP, 9.9.2024) 
+        // Automatically add missing xml:ids
+        // I replace the parent element to prevent hickups and endless recursions
+        // because replaceInEditor() needs xml:ids to work. 
+        // This can definitely be solved in a better way,
+        // but I'm not familar enough with the other editor functions
         elId = utils.generateXmlId(elName, v.xmlIdStyle);
         markupEl.setAttributeNS(dutils.xmlNameSpace, 'xml:id', elId);
+        replaceInEditor(cm, markupEl.parentElement, false);
+        cm.execCommand('indentAuto');
+        console.log(`Added xml:id ${elId} to ${elName}`);
       }
 
       if (att.alternativeEncodingElements.includes(elName)) {


### PR DESCRIPTION
Items in the list basically need xml:ids to work properly. Warning users to add xml:ids was not convenient, because this warning would be raised at every key stroke.

Now, when a markup element is detected, an xml:id is silently generated and added. The interaction with the bubble works so far.

Should we add this functionality for `<annot>` to? We also need to catch `<annots>` without `@plist` because the whole layer is currently highlighted.