### PR TITLE
Fix top-right controls being forced offscreen for long filenames

### DIFF
--- a/app/static/css/navbar.css
+++ b/app/static/css/navbar.css
@@ -278,13 +278,23 @@
   max-height: calc(1em + 2px);
 }
 
+.fileStatus .fileNameContainer {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.fileStatus :is(.fileNameContainer:hover, .fileNameContainer:active) {
+  overflow: visible;
+  text-overflow: initial;
+  text-wrap: wrap;
+}
+
 .fileStatus #fileName {
   white-space: pre;
 }
 
 .fileStatus #fileChanged {
-  margin-left: -0.2em;
-  margin-right: 0.5em;
+  margin-left: 0.2em;
 }
 
 .fileStatus.changed {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -650,9 +650,11 @@
       </div>
       <div class="fileStatus">
         <span id="schemaStatus" class="manual">&nbsp;?&nbsp;</span>
-        <span id="fileLocation"></span>
-        <span id="fileName"></span>
         <span id="fileChanged"></span>
+        <span class="fileNameContainer">
+          <span id="fileLocation"></span>
+          <span id="fileName"></span>
+        </span>
         <span id="fileStorageExceeded"></span>
       </div>
       <div class="fillSpace"></div>


### PR DESCRIPTION
When the name of the current file is too long, it forces the controls in the top-right of the menubar offscreen, rendering the settings, facsimile and annotations panels, etc. buttons unclickable.

This change truncates the filename with a continuation indicator (...). On mouseover or focus, the full filename shown while still allowing the top-right buttons to be clicked.

Now that the right-hand edge of the file name area is no longer reliably the end of the filename, it looks visually confusing to have the file-changed-indicator there. This change moves it to the left-hand side of the filename.

Proposed behavior:

https://github.com/user-attachments/assets/11c419bb-adea-4e2c-ab78-94f8c7feb421



