### PR TITLE
Fix error in markup for accid & artic

### DIFF
--- a/app/static/lib/markup.js
+++ b/app/static/lib/markup.js
@@ -437,7 +437,7 @@ function addMarkupToXML(v, cm, attrName = 'none', mElName, multiLayerContent = [
           // make new element out of attribute and handle it as element to be surrounded
           let attrValue = el.getAttribute(attrName);
           let attrEl = document.createElementNS(dutils.meiNameSpace, attrName);
-          let uuid = mintSuppliedId(id, attrName);
+          let uuid = mintSuppliedId(id, attrName, v);
           attrEl.setAttributeNS(dutils.xmlNameSpace, 'xml:id', uuid);
           attrEl.setAttribute(attrName, attrValue);
           el.removeAttribute(attrName);


### PR DESCRIPTION
There was a small bug when adding markup for accidentals and articulation using the default selection dropdown. This is now fixed and tested locally.

Thanks @sstremel for spotting this! 🙂 