### PR TITLE
Added modification of dependen IDs from copied elements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,14 @@
         {
             "type": "chrome",
             "request": "launch",
-            "name": "mei-friend",
+            "name": "mei-friend Chrome",
+            "url": "http://localhost:5001",
+            "webRoot": "${workspaceFolder}/app"
+        },
+        {
+            "type": "firefox",
+            "request": "launch",
+            "name": "mei-friend Firefox",
             "url": "http://localhost:5001",
             "webRoot": "${workspaceFolder}/app"
         }


### PR DESCRIPTION
When elements are copied for a markup dependend IDs like startid and endid will be modified to those of also copied elements (e.g. copying notes and a slur will update the ids of the slur, so that it points to the copied notes).