### PR TITLE
Prevent loop of infinity for empty <app>

### DIFF
--- a/app/static/lib/markup.js
+++ b/app/static/lib/markup.js
@@ -269,6 +269,7 @@ export function selectApparatus(xmlDoc, sourceId = '') {
       changeFlag = true;
     } else {
       console.log('This app has neither lemma nor reading elements. ', app);
+      app.remove();
     }
   }
 


### PR DESCRIPTION
Quick fix, `<app>` needs future improvement anyway. This just prevents the loop of infinite doom.

Fixes the issue of running into aninfinite loop when typing an `<app>` before having the chance to add `<rdg>` or `<lem>`.