### PR TITLE
Fix switching to added variant after inserting choice/subst

### DIFF
--- a/app/static/lib/markup.js
+++ b/app/static/lib/markup.js
@@ -374,8 +374,10 @@ export function addMarkup(event) {
           newSelection.push(child.getAttribute('xml:id'));
         }
       });
-      v.selectedElements = newSelection;
       setChoiceOptions(multiLayerContent[multiLayerContent.length - 1]);
+      handleEditorChanges();
+      v.selectedElements = newSelection;
+      v.setFocusToVerovioPane();
     }
   }
 } // addMarkup()


### PR DESCRIPTION
When adding choice/subst, I deliberately change the Verovio view to the second (newly added) child and select its content to allow immediate modification.  
This didn't work properly anymore after our great cleaning and hacking action.

Since the switching between versions generally works fine, I modified only the section in `addMarkup()` that toggles this special behaviour.
The problem was that after cleaning some unnecessary refreshes, speed mode didn't update itself after the selection was set.
Because we need to update the changes in the file with `handleEditorChanges()` to fill the choiceOptions dropdown with options. This option is then manually set, but nothing forced an update of the speed mode. The newly added  `handleEditorChanges()` fixes this.
Looks clunky but it works... but since the problem only occurs in this special behaviour after adding choice/subst, a fix in that bit of code causes the least trouble.
Setting the focus to the Verovio pane afterwards is necessary to allow edits.