### PR TITLE
Run E2E tests with GitHub Actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,11 +25,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
 
       - name: Install Python dependencies
         run: |
@@ -52,9 +54,19 @@ jobs:
           echo "FLASK_SECRET=dummy_secret" >> .env
           echo "TEST_URL=http://localhost:5001" >> .env
 
-      - name: Install Playwright
-        run: |
-          npx playwright install chromium --with-deps
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright system deps
+        run: npx playwright install-deps chromium
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium
 
       - name: Output Playwright Version
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Wait for server to be ready
         run: |
           echo "Waiting for server to be ready..."
-          timeout 60s bash -c 'until curl -s http://localhost:5001 > /dev/null; do sleep 1; done'
+          timeout 60s bash -c 'until curl -sf http://localhost:5001 > /dev/null; do sleep 1; done'
           echo "Server is ready! Response from server:"
           curl -i http://localhost:5001
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,97 @@
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    # On the latest ubuntu-24.04, Playwright cannot resolve package 'libasound2' during installation. 
+    # Upgrading @playwright/test to v1.44 or later should make it work on ubuntu-24.04 as well.
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Required to clone CodeMirror which is included as a git submodule
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Install Node.js dependencies
+        run: |
+          npm install
+
+      - name: Build CodeMirror
+        run: |
+          cd app/static/CodeMirror
+          npm install
+          npm run build
+
+      - name: Prepare environment
+        run: |
+          cp env-template .env
+          echo "FLASK_SECRET=dummy_secret" >> .env
+          echo "TEST_URL=http://localhost:5001" >> .env
+
+      - name: Install Playwright
+        run: |
+          npx playwright install chromium --with-deps
+
+      - name: Output Playwright Version
+        run: |
+          npx playwright --version
+
+      - name: Start Flask server
+        run: |
+          export FLASK_APP=app
+          python -m flask run --port=5001 &
+        env:
+          FLASK_ENV: development
+
+      - name: Wait for server to be ready
+        run: |
+          echo "Waiting for server to be ready..."
+          timeout 60s bash -c 'until curl -s http://localhost:5001 > /dev/null; do sleep 1; done'
+          echo "Server is ready! Response from server:"
+          curl -i http://localhost:5001
+
+      - name: Run the first E2E test to verify the setup
+        # Run a single test first to verify that the CI playwright setup and server connection are working correctly
+        run: |
+          cd e2e
+          npx playwright test --config=../playwright.config.js --project=chromium -g "1 Test settings panel" --retries=3 --reporter=github,html
+        env:
+          TEST_URL: http://localhost:5001
+
+      - name: Run All E2E Tests
+        run: |
+          cd e2e
+          npx playwright test --config=../playwright.config.js --project=chromium --retries=3 --reporter=github,html
+        env:
+          TEST_URL: http://localhost:5001
+
+      - name: Upload Playwright Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build CodeMirror
         run: |
           cd app/static/CodeMirror
-          npm ci
+          npm install
           npm run build
 
       - name: Prepare environment

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,9 +13,7 @@ on:
 
 jobs:
   test:
-    # On the latest ubuntu-24.04, Playwright cannot resolve package 'libasound2' during installation. 
-    # Upgrading @playwright/test to v1.44 or later should make it work on ubuntu-24.04 as well.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,11 +63,12 @@ jobs:
           npx playwright --version
 
       - name: Start Flask server
-        run: |
-          export FLASK_APP=app
-          python -m flask run --port=5001 &
         env:
-          FLASK_ENV: development
+          FLASK_APP: app
+          PYTHONUNBUFFERED: "1"
+        run: |
+          nohup python -m flask run --port=5001 > flask.log 2>&1 &
+          echo $! > flask.pid
 
       - name: Wait for server to be ready
         run: |
@@ -90,11 +91,19 @@ jobs:
           npx playwright test --config=../playwright.config.js --project=chromium --retries=3 --reporter=github,html
         env:
           TEST_URL: http://localhost:5001
-
+          
+      - name: Show Flask log on failure
+        if: failure()
+        run: |
+          echo "---- last 200 lines of flask.log ----"
+          tail -n 200 flask.log || true
+          
       - name: Upload Playwright Report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: playwright-report/
+          path: |
+            playwright-report/
+            flask.log
           retention-days: 30

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,10 @@ name: E2E Tests
 on:
   push:
     branches:
-      - '**'
+      - 'main'
+      - 'staging'
+      - 'develop'
+      - 'testing'
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -21,6 +22,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,12 +47,12 @@ jobs:
 
       - name: Install Node.js dependencies
         run: |
-          npm install
+          npm ci
 
       - name: Build CodeMirror
         run: |
           cd app/static/CodeMirror
-          npm install
+          npm ci
           npm run build
 
       - name: Prepare environment


### PR DESCRIPTION
To verify the current E2E testing and for future maintenance, I've implemented E2E testing via GitHub Actions.
The workflow closely follows the local setup instructions in `INSTALL.md`.

Please note that the tests currently fail.  
Also, a 30-second timeout occurs during the tests. Please note that these tests will be retried three times, resulting in longer test execution times.

Even if the tests fail, the Pull Request remains mergeable. If you wish to change this behavior in the future, you will need to configure GitHub's Branch Protection Rules.

Related issue: https://github.com/mei-friend/mei-friend/issues/181